### PR TITLE
Fix typo in ActivityStart.tsx

### DIFF
--- a/extensions/moco/src/commands/activities/components/ActivityStart.tsx
+++ b/extensions/moco/src/commands/activities/components/ActivityStart.tsx
@@ -84,7 +84,7 @@ export const ActivityStart: React.FC<ActivityStartProps> = ({ task, projectID })
         onChange={dropDescriptionErrorIfNeeded}
         onBlur={(event) => {
           if (event.target.value?.length == 0) {
-            setDescriptionError("The field should't be empty!");
+            setDescriptionError("The field shouldn't be empty!");
           } else {
             dropDescriptionErrorIfNeeded();
           }


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->

Fixing a typo in the description error message in the ActivityStart.tsx.

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
