### PR TITLE
Make hourly_rate an optional parameter

### DIFF
--- a/extensions/moco/src/commands/activities/api.ts
+++ b/extensions/moco/src/commands/activities/api.ts
@@ -45,7 +45,7 @@ const activitySchema = z.array(
       firstname: z.string(),
       lastname: z.string(),
     }),
-    hourly_rate: z.number(),
+    hourly_rate: z.number().optional(),
     timer_started_at: z.nullable(z.string()),
     created_at: z.string(),
     updated_at: z.string(),

--- a/extensions/moco/src/commands/activities/types.ts
+++ b/extensions/moco/src/commands/activities/types.ts
@@ -21,7 +21,7 @@ export type Activity = {
   task: Task;
   customer: Customer;
   user: User;
-  hourly_rate: number;
+  hourly_rate?: number;
   timer_started_at: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Description

When activities do not have an `hourly_rate` it right now runs into an error as the type right now expects a value for that. With that PR it will make the `hourly_rate` an optional parameter, so it should not run in an error anymore hopefully.

That is related to this issue: https://github.com/eviscares/extensions/issues/14

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [ ] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [ ] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [ ] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [ ] I checked that files in the `assets` folder are used by the extension itself
- [ ] I checked that assets used by the `README` are placed outside of the `metadata` folder
