### PR TITLE
Fix/hide inactive

### DIFF
--- a/extensions/moco/CHANGELOG.md
+++ b/extensions/moco/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MOCO Changelog
 
+## [v1.1.2] - 2024-06-28
+- Made hourly rate field non required
+
 ## [v1.1.1] - 2023-04-05
 - Hours worked can now be entered in a non decimal way reliably
 

--- a/extensions/moco/src/commands/activities/components/ActivityStart.tsx
+++ b/extensions/moco/src/commands/activities/components/ActivityStart.tsx
@@ -70,9 +70,8 @@ export const ActivityStart: React.FC<ActivityStartProps> = ({ task, projectID })
           {selectedProjectID !== "0"
             ? projects
                 .filter((project) => project.id === parseInt(selectedProjectID!))[0]
-                .tasks.map((task, index) => (
-                  <Form.Dropdown.Item title={task.name} key={index} value={task.id!.toString()} />
-                ))
+                .tasks.filter((task) => task.active)
+                .map((task, index) => <Form.Dropdown.Item title={task.name} key={index} value={task.id!.toString()} />)
             : null}
         </Form.Dropdown>
       ) : null}


### PR DESCRIPTION
## Description
Makes the hourly rate field not required, hopefully allowing users with less privileges in the api to use the extension correctly.

## Screencast

Not applicable

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
